### PR TITLE
Add stopped icon support when no player runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Description: A string to display for `{icon}` component when the music player
 is paused  
 Default: ` ` (empty space)  
 Values: string
+- `@now-playing-stopped-icon`  
+Description: A string to display for `{icon}` component when there is no music player running  
+Default: ` ` (empty space)  
+Values: string
 - `@now-playing-keytable`  
 Description: A string that is bound in the key table for combinating keys.  
 Default: `prefix`  

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -81,7 +81,8 @@ main() {
 
   if test -z "$music_data"; then
     # no player is running
-    printf ""
+    local player_icon="$(get_tmux_option "@now-playing-stopped-icon" "")"
+    printf "$player_icon"
     if test "$(get_tmux_option "@now-playing-auto-interval" "no")" = "yes"; then
       set_tmux_option "status-interval" "$(get_tmux_option "@now-playing-paused-interval" "5")"
     fi


### PR DESCRIPTION
- docs(readme): document @now-playing-stopped-icon option for icon display when no music player is running
- feat(scripts/music.sh): print stopped icon from @now-playing-stopped-icon if no player is detected and adjust status-interval accordingly