### PR TITLE
Add media-control player support with new detection and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Showing currently playing track in tmux status bar with music controls
 - (Windows through WSL only, experimental) `cscript` (Windows Script Host) - enable the following integrations and more in the future
   - iTunes
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
+- [Cider](https://cider.sh) through `curl` and `jq`
 - [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
 
 ## Configurations
@@ -56,19 +57,19 @@ Values: string
 - `@now-playing-play-pause-key`  
 Description: A list of key to bind as a play/pause command  
 Default: `,`  
-Values: a space separated string
+Values: space separated string
 - `@now-playing-stop-key`  
 Description: A list of key to bind as a stop command  
 Default: `.`  
-Values: a space separated string
+Values: space separated string
 - `@now-playing-previous-key`  
 Description: A list of key to bind as a previous track command  
 Default: `;`  
-Values: a space separated string
+Values: space separated string
 - `@now-playing-next-key`  
 Description: A list of key to bind as a next track command  
 Default: `'`  
-Values: a space separated string
+Values: space separated string
 
 ### Update Interval
 
@@ -96,6 +97,18 @@ Values: string
 Description: A port number of MPD server  
 Default: `6600`  
 Values: number
+- `@now-playing-cider-host`  
+Description: An IP address to Cider web server  
+Default: `127.0.0.1`  
+Values: string
+- `@now-playing-cider-port`  
+Description: A port number of Cider web server  
+Default: `10767`  
+Values: number
+- `@now-playing-cider-token`  
+Description: An API token for Cider web server  
+Default: `` (empty string)
+Values: string (leave empty for no token)
 - `@now-playing-nowplaying-cli-include-music-app`  
 Description: A boolean string to indicate whether to have Apple's Music app
 processed through nowplaying-cli (which is quite flaky) or not  

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Showing currently playing track in tmux status bar with music controls
   - iTunes / Music
 - (Windows through WSL only, experimental) `cscript` (Windows Script Host) - enable the following integrations and more in the future
   - iTunes
+- (Linux) [`playerctl`](https://github.com/altdesktop/playerctl) - services or apps that support the [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/) specification, such as
+  - Spotify
+  - YouTube Music (under Firefox or Chrome)
+  - VLC
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [Cider](https://cider.sh) through `curl` and `jq`
 - [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
-- (Linux) anything that supports MPRIS through `playerctl`
-  - Spotify 
-  - probably can work with other players 
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Showing currently playing track in tmux status bar with music controls
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [Cider](https://cider.sh) through `curl` and `jq`
 - [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
+- (Linux) anything that supports MPRIS through `playerctl`
+  - Spotify 
+  - probably can work with other players 
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Showing currently playing track in tmux status bar with music controls
   - VLC
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [Cider](https://cider.sh) through `curl` and `jq`
-- [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
+- [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli) (Note: [not compatible with macOS Tahoe](https://github.com/kirtan-shah/nowplaying-cli/issues/28))
+- [`media-control`](https://github.com/ungive/media-control) - macOS media control CLI tool (recommended for macOS Tahoe and above)
 
 ## Configurations
 
@@ -117,6 +118,11 @@ Values: string (leave empty for no token)
 Description: A boolean string to indicate whether to have Apple's Music app
 processed through nowplaying-cli (which is quite flaky) or not  
 Default: `no`  
+Values: `0` / `no` / `false` / `1` / `yes` / `true`
+- `@now-playing-media-control-include-music-app`  
+Description: A boolean string to indicate whether to have Apple's Music app
+processed through media-control or not  
+Default: `yes`  
 Values: `0` / `no` / `false` / `1` / `yes` / `true`
 
 #### Components

--- a/players/applescript.sh
+++ b/players/applescript.sh
@@ -9,7 +9,14 @@ source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
 is_running() {
   # Only macOS with osascript command
   if test "$(uname)" = "Darwin" -a -n "$(command -v osascript)"; then
-    return 0
+    # Check if we're on macOS Tahoe (Darwin 25) or above
+    local darwin_version="$(uname -r | cut -d. -f1)"
+    if test "$darwin_version" -ge 25; then
+      # macOS Tahoe and above - AppleScript currentTrack is broken
+      return 1
+    else
+      return 0
+    fi
   else
     return 1
   fi

--- a/players/cider.sh
+++ b/players/cider.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
+source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
+
+CIDER_HOST="$(get_tmux_option "@now-playing-cider-host" "127.0.0.1")"
+CIDER_PORT="$(get_tmux_option "@now-playing-cider-port" "10767")"
+CIDER_TOKEN="$(get_tmux_option "@now-playing-cider-token" "")"
+
+parse_json() {
+  printf '%s' "$1" | jq -rc "$2"
+}
+
+cider() {
+  parse_json "$(curl -sSL "$CIDER_HOST:$CIDER_PORT/api/v1/playback$1")" "$2"
+}
+
+is_running() {
+  if ! test -n "$(command -v curl)" -a -n "$(command -v jq)"; then
+    return 1
+  fi
+  if test "$(cider /active .status)" != 'ok'; then
+    return 1
+  fi
+  return 0
+}
+
+is_playing() {
+  if ! is_running; then
+    return 1
+  fi
+
+  _cider_status() {
+    cider /now-playing '.info.currentPlaybackTime | type'
+  }
+
+  local cider_status="$(_cache_value cider_status _cider_status)"
+
+  if test "$cider_status" != "number"; then
+    return 1
+  fi
+
+  return 0
+}
+
+get_music_data() {
+  _cider_state() {
+    cider /is-playing '.is_playing'
+  }
+  local cider_state="$(_cache_value cider_state _cider_state)"
+  _cider_data() {
+    cider /now-playing .
+  }
+  local cider_data="$(_cache_value cider_data _cider_data)"
+
+  local position="$(parse_json "$cider_data" '.info.currentPlaybackTime // 0 | floor')"
+  local duration="$(parse_json "$cider_data" '(.info.durationInMillis // 0) / 1000 | floor')"
+  local title="$(parse_json "$cider_data" .info.name)"
+  local artist="$(parse_json "$cider_data" .info.artistName)"
+
+  local status=""
+  if test "$cider_state" = "true"; then
+    status="playing"
+  else
+    status="paused"
+  fi
+
+  printf "%s\n%s\n%s\n%s\n%s\nCider" "$status" "$position" "$duration" "$title" "$artist"
+}
+
+send_command() {
+  sh -c "(printf \"$1\nclose\n\"; sleep 0.05) | nc \"$CIDER_HOST\" \"$CIDER_PORT\"" > /dev/null
+}

--- a/players/cider.sh
+++ b/players/cider.sh
@@ -13,8 +13,20 @@ parse_json() {
   printf '%s' "$1" | jq -rc "$2"
 }
 
+http_req() {
+  curl -sSL -X "$1" "$CIDER_HOST:$CIDER_PORT/api/v1/playback$2"
+}
+
+http_get() {
+  http_req GET "$1"
+}
+
+http_post() {
+  http_req POST "$1"
+}
+
 cider() {
-  parse_json "$(curl -sSL "$CIDER_HOST:$CIDER_PORT/api/v1/playback$1")" "$2"
+  parse_json "$(http_get "$1")" "$2"
 }
 
 is_running() {
@@ -71,5 +83,14 @@ get_music_data() {
 }
 
 send_command() {
-  sh -c "(printf \"$1\nclose\n\"; sleep 0.05) | nc \"$CIDER_HOST\" \"$CIDER_PORT\"" > /dev/null
+  local remote_command="$1"
+  if test "$remote_command" = "pause"; then
+    http_post /playpause >/dev/null
+  elif test "$remote_command" = "stop"; then
+    http_post /stop >/dev/null
+  elif test "$remote_command" = "previous"; then
+    http_post /previous >/dev/null
+  elif test "$remote_command" = "next"; then
+    http_post /next >/dev/null
+  fi
 }

--- a/players/media-control.sh
+++ b/players/media-control.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
+source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
+
+INCLUDE_MUSIC="$(get_tmux_option "@now-playing-media-control-include-music-app" "yes")"
+
+include_music() {
+  case "$INCLUDE_MUSIC" in
+    yes|true|1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_running() {
+  if test -n "$(command -v media-control)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_playing() {
+  if ! is_running; then
+    return 1
+  fi
+
+  local json_data="$(media-control get 2>/dev/null)"
+  if test $? -ne 0 || test -z "$json_data"; then
+    return 1
+  fi
+
+  local playback_rate="$(printf "%s" "$json_data" | jq -r '.playbackRate // 0' 2>/dev/null)"
+  local bundle_id="$(printf "%s" "$json_data" | jq -r '.bundleIdentifier // ""' 2>/dev/null)"
+
+  if test "$playback_rate" = "0" || test "$playback_rate" = "null"; then
+    return 1
+  elif test "$bundle_id" = "com.apple.Music" && ! include_music; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+get_music_data() {
+  local json_data="$(media-control get 2>/dev/null)"
+  
+  if test $? -ne 0 || test -z "$json_data"; then
+    printf "stopped\n0\n0\n\n\nmedia-control"
+    return
+  fi
+
+  local playback_rate="$(printf "%s" "$json_data" | jq -r '.playbackRate // 0' 2>/dev/null)"
+  local position="$(printf "%s" "$json_data" | jq -r '.position // 0' 2>/dev/null | awk '{print int($0)}')"
+  local duration="$(printf "%s" "$json_data" | jq -r '.duration // 0' 2>/dev/null | awk '{print int($0)}')"
+  local title="$(printf "%s" "$json_data" | jq -r '.title // ""' 2>/dev/null)"
+  local artist="$(printf "%s" "$json_data" | jq -r '.artist // ""' 2>/dev/null)"
+
+  local status="playing"
+  if test "$playback_rate" = "0" || test "$playback_rate" = "null"; then
+    status="paused"
+  fi
+
+  printf "%s\n%s\n%s\n%s\n%s\nmedia-control" "$status" "$position" "$duration" "$title" "$artist"
+}
+
+send_command() {
+  local remote_command="$1"
+  case "$remote_command" in
+    "pause"|"playpause")
+      media-control toggle-play-pause
+      ;;
+    "stop")
+      media-control pause
+      ;;
+    "previous")
+      media-control previous-track
+      ;;
+    "next")
+      media-control next-track
+      ;;
+    *)
+      # Default to toggle play/pause for unknown commands
+      media-control toggle-play-pause
+      ;;
+  esac
+}

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
+source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
+
+is_running() {
+
+  if (playerctl status | grep "No players found") then 
+    return 1
+  else # Player is found, but not playing (i.e. stopped or paused)
+    return 0
+  fi
+}
+
+is_playing() {
+  if ! is_running; then # Isn't running 
+    return 1
+  fi
+
+  local player_status="$(playerctl status)"
+
+  if test "$player_status" = "Paused"; then
+    return 1
+  fi
+
+  return 0
+}
+
+get_music_data() {
+
+  _playerctl_data() {
+    sh -c "playerctl metadata"
+  }
+
+
+  local status="$(playerctl status)"
+  local title="$(playerctl metadata xesam:artist)"
+  local artist="$(playerctl metadata xesam:title)"
+
+  # MPRIS provides the length in us, then we will need to do a bit of math here.
+   
+  local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
+
+  local position="$(playerctl position | cut -d. -f1)"
+
+  #local mpd_state="$(printf "%s" "$mpd_data" | awk '$1 ~ /^state:/ { print $2 }' | cut -d':' -f1)"
+  #local position="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f1)"
+  #local duration="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f2)"
+  #local title="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Title:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
+  #local artist="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Artist:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
+
+  local playerctl_status="$(playerctl status)"
+
+  if test "$playerctl_status" = "Playing"; then
+    status="playing"
+  elif test "$playerctl_status" = "Paused"; then
+    status="paused"
+  fi
+
+  printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
+}
+

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -6,8 +6,7 @@ source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
 source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
 
 is_running() {
-
-  if (playerctl status | grep "No players found") then 
+  if (playerctl status | grep -q "No players found") then
     return 1
   else # Player is found, but not playing (i.e. stopped or paused)
     return 0
@@ -15,7 +14,7 @@ is_running() {
 }
 
 is_playing() {
-  if ! is_running; then # Isn't running 
+  if ! is_running; then
     return 1
   fi
 
@@ -29,7 +28,6 @@ is_playing() {
 }
 
 get_music_data() {
-
   local status="$(playerctl status ; sleep 1)"
   local title="$(playerctl metadata xesam:artist)"
   local artist="$(playerctl metadata xesam:title)"
@@ -37,9 +35,7 @@ get_music_data() {
   # MPRIS provides the length in us, then we will need to do a bit of math here.
    
   local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
-
   local position="$(playerctl position | cut -d. -f1)"
-
   local playerctl_status="$(playerctl status)"
 
   if test "$playerctl_status" = "Playing"; then
@@ -48,7 +44,7 @@ get_music_data() {
     status="paused"
   fi
 
-  printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
+  printf "%s\n%s\n%s\n%s\n%s\nplayerctl" "$status" "$position" "$duration" "$artist" "$title"
 }
 
 send_command() {

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -30,12 +30,7 @@ is_playing() {
 
 get_music_data() {
 
-  _playerctl_data() {
-    sh -c "playerctl metadata"
-  }
-
-
-  local status="$(playerctl status)"
+  local status="$(playerctl status ; sleep 1)"
   local title="$(playerctl metadata xesam:artist)"
   local artist="$(playerctl metadata xesam:title)"
 
@@ -44,12 +39,6 @@ get_music_data() {
   local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
 
   local position="$(playerctl position | cut -d. -f1)"
-
-  #local mpd_state="$(printf "%s" "$mpd_data" | awk '$1 ~ /^state:/ { print $2 }' | cut -d':' -f1)"
-  #local position="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f1)"
-  #local duration="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f2)"
-  #local title="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Title:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
-  #local artist="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Artist:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
 
   local playerctl_status="$(playerctl status)"
 

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -51,3 +51,12 @@ get_music_data() {
   printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
 }
 
+send_command() {
+  local remote_command="$1"
+
+  if test "$remote_command" = "pause"; then
+    playerctl play-pause
+  else
+    playerctl "$remote_command"
+  fi
+}

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -6,6 +6,9 @@ source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
 source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
 
 is_running() {
+  if ! test -n "$(command -v playerctl)"; then
+    return 1
+  fi
   if (playerctl status | grep -q "No players found") then
     return 1
   else # Player is found, but not playing (i.e. stopped or paused)
@@ -20,7 +23,7 @@ is_playing() {
 
   local player_status="$(playerctl status)"
 
-  if test "$player_status" = "Paused"; then
+  if test "$player_status" = "Stopped"; then
     return 1
   fi
 
@@ -32,8 +35,7 @@ get_music_data() {
   local title="$(playerctl metadata xesam:artist)"
   local artist="$(playerctl metadata xesam:title)"
 
-  # MPRIS provides the length in us, then we will need to do a bit of math here.
-   
+  # MPRIS provides the length in microsecond, then we will need to do a bit of math here.
   local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
   local position="$(playerctl position | cut -d. -f1)"
   local playerctl_status="$(playerctl status)"

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -8,6 +8,7 @@ source "$CURRENT_DIR/shada.sh"
 
 players=(
   "$(dirname "$CURRENT_DIR")/players/nowplaying-cli.sh"
+  "$(dirname "$CURRENT_DIR")/players/cider.sh"
   "$(dirname "$CURRENT_DIR")/players/mpd.sh"
   "$(dirname "$CURRENT_DIR")/players/applescript.sh"
   "$(dirname "$CURRENT_DIR")/players/cscript.sh"
@@ -28,7 +29,7 @@ send_command() {
 replace() {
   local str="$1"
   local find="$2"
-  local replacement="${3//&/\\&}"
+  local replacement="$3"
   printf '%s' "${str//$find/$replacement}"
 }
 

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -9,6 +9,7 @@ source "$CURRENT_DIR/shada.sh"
 players=(
   "$(dirname "$CURRENT_DIR")/players/nowplaying-cli.sh"
   "$(dirname "$CURRENT_DIR")/players/cider.sh"
+  "$(dirname "$CURRENT_DIR")/players/media-control.sh"
   "$(dirname "$CURRENT_DIR")/players/mpd.sh"
   "$(dirname "$CURRENT_DIR")/players/applescript.sh"
   "$(dirname "$CURRENT_DIR")/players/cscript.sh"

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -12,6 +12,7 @@ players=(
   "$(dirname "$CURRENT_DIR")/players/mpd.sh"
   "$(dirname "$CURRENT_DIR")/players/applescript.sh"
   "$(dirname "$CURRENT_DIR")/players/cscript.sh"
+  "$(dirname "$CURRENT_DIR")/players/playerctl.sh"
 )
 
 is_playing() {


### PR DESCRIPTION
# Changes
- feat(media-control): add new player script using media-control CLI for playback info and commands
- fix(players/applescript): add macOS Tahoe check to disable broken AppleScript currentTrack support
- chore(scripts): include media-control player in music players array for detection